### PR TITLE
Как /try, только для космонавтиков

### DIFF
--- a/code/modules/client/preference_setup/global/prefixes.dm
+++ b/code/modules/client/preference_setup/global/prefixes.dm
@@ -27,3 +27,7 @@
 /decl/prefix/custom_emote
 	name = "Emote, custom"
 	default_key = "*"
+
+/decl/prefix/try_emote
+	name = "Try emote, custom"
+	default_key = "%"

--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -141,6 +141,23 @@
 	else
 		audible_message(message, checkghosts = check_ghosts)
 
+/mob/living/proc/try_emote(var/message)
+	if((usr && stat) || (!use_me && usr == src))
+		to_chat(src, "You are unable to emote.")
+		return
+	if(!message)
+		return
+
+	message = format_emote(src, message)
+
+	if(prob(50))
+		message += "<span class='good'> Успех!</span>"
+	else
+		message += "<span class='danger'> Провал!</span>"
+
+	visible_message(message)
+	log_emote("[name]/[key] : [message]")
+
 // Specific mob type exceptions below.
 /mob/living/silicon/ai/emote(var/act, var/type, var/message)
 	var/obj/machinery/hologram/holopad/T = src.holo

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -192,6 +192,8 @@ proc/get_radio_key_from_channel(var/channel)
 		return emote(copytext(message,2))
 	if(prefix == get_prefix_key(/decl/prefix/visible_emote))
 		return custom_emote(1, copytext(message,2))
+	if(prefix == get_prefix_key(/decl/prefix/try_emote))
+		return try_emote(copytext(message,2))
 
 	//parse the radio code and consume it
 	var/message_mode = parse_message_mode(message, "headset")


### PR DESCRIPTION
Позволяет зароллить действие, использовав префикс % в начале сообщения.